### PR TITLE
SAM-40 move /smz to /smz/pwa

### DIFF
--- a/Caddyfile.footer
+++ b/Caddyfile.footer
@@ -26,7 +26,7 @@
         reverse_proxy 192.168.42.1:8000
     }
 
-    handle_path /smz* {
+    handle_path /smz/pwa* {
         import corsify
         route {
             root * /next/
@@ -48,6 +48,6 @@
     }
 
     handle / {
-        redir / /smz
+        redir / /smz/pwa
     }
 }


### PR DESCRIPTION
One or two references to `/smz` remain in place as they reference the namespace, not the bootstrap app.